### PR TITLE
modify logic

### DIFF
--- a/Assets/Game Code/Systems/Input/CommandMoveSystem.cs
+++ b/Assets/Game Code/Systems/Input/CommandMoveSystem.cs
@@ -30,14 +30,7 @@ public class CommandMoveSystem : ReactiveSystem<InputEntity>
             if (movers.Length <= 0) return;
 
             GameEntity mover = movers[Random.Range(0, movers.Length)];
-            if (mover.hasMove)
-            {
-                mover.ReplaceMove(e.mouseDown.position);
-            }
-            else
-            {
-                mover.AddMove(e.mouseDown.position);
-            }
+            mover.AddMove(e.mouseDown.position);
         }
     }
 }


### PR DESCRIPTION
Because _movers is the group of "GameMatcher.AllOf(GameMatcher.Mover).NoneOf(GameMatcher.Move)" so it will always have no movecomponent and also the logic of"mover.hasmove" is always false.